### PR TITLE
Added Min and Max to pactum-matchers for `int` and `float`

### DIFF
--- a/src/compare.js
+++ b/src/compare.js
@@ -208,14 +208,14 @@ function compareWithAny(actual, rule, path) {
 }
 
 function compareWithInt(actual, rule, path) {
-  console.log(actual);
-  console.log(rule);
-  console.log(path);
+  console.warn(actual);
+  console.warn(rule);
+  console.warn(path);
   const type = getType(actual);
   if (type !== 'number') {
     throw `Json doesn't have type 'number' at '${path}' but found '${type}'`;
   } else {
-    console.log(rule);
+    console.warn(rule);
     if ('options' in rule) {
       const options = rule.options;
       if ('min' in rule) {

--- a/src/compare.js
+++ b/src/compare.js
@@ -209,7 +209,7 @@ function compareWithAny(actual, rule, path) {
 
 function compareWithInt(actual, rule, path) {
   const type = getType(actual);
-  console.log(rule);
+  if (rule.options) console.log(rule);
   if (type !== 'number') {
     throw `Json doesn't have type 'number' at '${path}' but found '${type}'`;
   } else {

--- a/src/compare.js
+++ b/src/compare.js
@@ -219,12 +219,14 @@ function compareWithInt(actual, rule, path) {
         if (typeof min !== 'number') {
           throw `Value for min of '${path}' is not a number`;
         } else if (actual < min) {
+          console.log(`${actual} < ${min}`)
           throw `Value ${actual} at '${path}' is less than minimum ${min}`
         }
         const max = options.max;
         if (typeof max !== 'number') {
           throw `Value for max of '${path}' is not a number`
         } else if (actual > max) {
+          console.log(`${actual} > ${max}`)
           throw `Value ${actual} at '${path}' is more than maximum ${max}`
         }
       }

--- a/src/compare.js
+++ b/src/compare.js
@@ -7,6 +7,7 @@ function compare(actual, expected, rules, path) {
 }
 
 function _compare(actual, expected, rules, regex_rules, path) {
+  console.log(rules);
   const rule = getCurrentPathRule(rules, regex_rules, path);
   if (rule) {
     compareWithRule(actual, expected, rules, regex_rules, path, rule);

--- a/src/compare.js
+++ b/src/compare.js
@@ -209,20 +209,22 @@ function compareWithAny(actual, rule, path) {
 
 function compareWithInt(actual, rule, path) {
   const type = getType(actual);
-  if (rule.options) console.log(rule);
   if (type !== 'number') {
     throw `Json doesn't have type 'number' at '${path}' but found '${type}'`;
   } else {
     if ('options' in rule) {
       const options = rule.options;
+      console.log(actual);
       if ('min' in rule) {
         const min = options.min;
+        console.log(`Minimum: ${min}`);
         if (typeof min !== 'number') {
           throw `Value for min of '${path}' is not a number`;
         } else if (actual < min) {
           throw `Value ${actual} at '${path}' is less than minimum ${min}`
         }
         const max = options.max;
+        console.log(`Minimum: ${max}`);
         if (typeof max !== 'number') {
           throw `Value for max of '${path}' is not a number`
         } else if (actual > max) {

--- a/src/compare.js
+++ b/src/compare.js
@@ -208,6 +208,9 @@ function compareWithAny(actual, rule, path) {
 }
 
 function compareWithInt(actual, rule, path) {
+  console.log(actual);
+  console.log(rule);
+  console.log(path);
   const type = getType(actual);
   if (type !== 'number') {
     throw `Json doesn't have type 'number' at '${path}' but found '${type}'`;

--- a/src/compare.js
+++ b/src/compare.js
@@ -214,17 +214,14 @@ function compareWithInt(actual, rule, path) {
   } else {
     if ('options' in rule) {
       const options = rule.options;
-      console.log(actual);
       if ('min' in rule) {
         const min = options.min;
-        console.log(`Minimum: ${min}`);
         if (typeof min !== 'number') {
           throw `Value for min of '${path}' is not a number`;
         } else if (actual < min) {
           throw `Value ${actual} at '${path}' is less than minimum ${min}`
         }
         const max = options.max;
-        console.log(`Minimum: ${max}`);
         if (typeof max !== 'number') {
           throw `Value for max of '${path}' is not a number`
         } else if (actual > max) {

--- a/src/compare.js
+++ b/src/compare.js
@@ -212,6 +212,7 @@ function compareWithInt(actual, rule, path) {
   if (type !== 'number') {
     throw `Json doesn't have type 'number' at '${path}' but found '${type}'`;
   } else {
+    console.log(rule);
     if ('options' in rule) {
       const options = rule.options;
       if ('min' in rule) {

--- a/src/compare.js
+++ b/src/compare.js
@@ -212,6 +212,23 @@ function compareWithInt(actual, rule, path) {
   if (type !== 'number') {
     throw `Json doesn't have type 'number' at '${path}' but found '${type}'`;
   } else {
+    if ('options' in rule) {
+      const options = rule.options;
+      if ('min' in rule) {
+        const min = options.min;
+        if (typeof min !== 'number') {
+          throw `Value for min of '${path}' is not a number`;
+        } else if (actual < min) {
+          throw `Value ${actual} at '${path}' is less than minimum ${min}`
+        }
+        const max = options.max;
+        if (typeof max !== 'number') {
+          throw `Value for max of '${path}' is not a number`
+        } else if (actual > max) {
+          throw `Value ${actual} at '${path}' is more than maximum ${max}`
+        }
+      }
+    }
     const pattern = patterns.INT;
     if (!pattern.test(actual)) {
       throw `Json doesn't have 'integer' number at '${path}' but found '${actual}'`;

--- a/src/compare.js
+++ b/src/compare.js
@@ -209,6 +209,7 @@ function compareWithAny(actual, rule, path) {
 
 function compareWithInt(actual, rule, path) {
   const type = getType(actual);
+  console.log(rule);
   if (type !== 'number') {
     throw `Json doesn't have type 'number' at '${path}' but found '${type}'`;
   } else {

--- a/src/compare.js
+++ b/src/compare.js
@@ -210,6 +210,7 @@ function compareWithAny(actual, rule, path) {
 function compareWithInt(actual, rule, path) {
   console.warn(actual);
   console.warn(rule);
+  throw rule;
   console.warn(path);
   const type = getType(actual);
   if (type !== 'number') {

--- a/src/compare.js
+++ b/src/compare.js
@@ -219,7 +219,6 @@ function compareWithInt(actual, rule, path) {
         if (typeof min !== 'number') {
           throw `Value for min of '${path}' is not a number`;
         } else if (actual < min) {
-          console.log(`${actual} < ${min}`)
           throw `Value ${actual} at '${path}' is less than minimum ${min}`
         }
       }
@@ -228,7 +227,6 @@ function compareWithInt(actual, rule, path) {
         if (typeof max !== 'number') {
           throw `Value for max of '${path}' is not a number`
         } else if (actual > max) {
-          console.log(`${actual} > ${max}`)
           throw `Value ${actual} at '${path}' is more than maximum ${max}`
         }
       }
@@ -245,6 +243,25 @@ function compareWithFloat(actual, rule, path) {
   if (type !== 'number') {
     throw `Json doesn't have type 'number' at '${path}' but found '${type}'`;
   } else {
+    if ('options' in rule && rule.options !== undefined) {
+      const options = rule.options;
+      if ('min' in options) {
+        const min = options.min;
+        if (typeof min !== 'number') {
+          throw `Value for min of '${path}' is not a number`;
+        } else if (actual < min) {
+          throw `Value ${actual} at '${path}' is less than minimum ${min}`
+        }
+      }
+      if ('max' in options) {
+        const max = options.max;
+        if (typeof max !== 'number') {
+          throw `Value for max of '${path}' is not a number`
+        } else if (actual > max) {
+          throw `Value ${actual} at '${path}' is more than maximum ${max}`
+        }
+      }
+    }
     const pattern = patterns.FLOAT;
     if (!pattern.test(actual)) {
       throw `Json doesn't have 'float' number at '${path}' but found '${actual}'`;

--- a/src/compare.js
+++ b/src/compare.js
@@ -214,7 +214,7 @@ function compareWithInt(actual, rule, path) {
   } else {
     if ('options' in rule) {
       const options = rule.options;
-      if ('min' in rule) {
+      if ('min' in options) {
         const min = options.min;
         if (typeof min !== 'number') {
           throw `Value for min of '${path}' is not a number`;
@@ -222,6 +222,8 @@ function compareWithInt(actual, rule, path) {
           console.log(`${actual} < ${min}`)
           throw `Value ${actual} at '${path}' is less than minimum ${min}`
         }
+      }
+      if ('max' in options) {
         const max = options.max;
         if (typeof max !== 'number') {
           throw `Value for max of '${path}' is not a number`

--- a/src/compare.js
+++ b/src/compare.js
@@ -7,7 +7,6 @@ function compare(actual, expected, rules, path) {
 }
 
 function _compare(actual, expected, rules, regex_rules, path) {
-  console.log(rules);
   const rule = getCurrentPathRule(rules, regex_rules, path);
   if (rule) {
     compareWithRule(actual, expected, rules, regex_rules, path, rule);
@@ -209,15 +208,10 @@ function compareWithAny(actual, rule, path) {
 }
 
 function compareWithInt(actual, rule, path) {
-  console.warn(actual);
-  console.warn(rule);
-  throw rule;
-  console.warn(path);
   const type = getType(actual);
   if (type !== 'number') {
     throw `Json doesn't have type 'number' at '${path}' but found '${type}'`;
   } else {
-    console.warn(rule);
     if ('options' in rule) {
       const options = rule.options;
       if ('min' in rule) {

--- a/src/compare.js
+++ b/src/compare.js
@@ -212,7 +212,7 @@ function compareWithInt(actual, rule, path) {
   if (type !== 'number') {
     throw `Json doesn't have type 'number' at '${path}' but found '${type}'`;
   } else {
-    if ('options' in rule) {
+    if ('options' in rule && rule.options !== undefined) {
       const options = rule.options;
       if ('min' in options) {
         const min = options.min;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -74,7 +74,7 @@ export function int(value?: number, options?: { min?: number, max?: number }): o
 /**
  * Float matching
  */
-export function float(value?: number): object;
+export function float(value?: number, options?: { min?: number, max?: number }): object;
 
 /**
  * Greater than given number matching

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -69,7 +69,7 @@ export function any(value?: any): object;
 /**
  * Int matching
  */
-export function int(value?: number): object;
+export function int(value?: number, options?: { min?: number, max?: number }): object;
 
 /**
  * Float matching

--- a/src/index.js
+++ b/src/index.js
@@ -125,10 +125,11 @@ function any(value) {
   };
 }
 
-function int(value) {
+function int(value, options) {
   return {
     value: value || 123,
-    pactum_type: 'INT'
+    pactum_type: 'INT',
+    options
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -133,10 +133,11 @@ function int(value, options) {
   };
 }
 
-function float(value) {
+function float(value, options) {
   return {
     value: value || 123.456,
-    pactum_type: 'FLOAT'
+    pactum_type: 'FLOAT',
+    options,
   };
 }
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -28,7 +28,7 @@ function setMatchingRules(rules, data, path) {
       rules[path] = { match: 'any' };
       break;
     default:
-      rules[path] = { match: data.pactum_type.toLowerCase() };
+      rules[path] = { match: data.pactum_type.toLowerCase(), options: data.options };
       break;
   }
 }

--- a/src/rules.js
+++ b/src/rules.js
@@ -1,7 +1,6 @@
 const { isPureObject, isObject } = require('./helpers');
 
 function setMatchingRules(rules, data, path) {
-  if (data.options) console.log(data);
   switch (data.pactum_type) {
     case 'LIKE':
       rules[path] = { match: 'type' };

--- a/src/rules.js
+++ b/src/rules.js
@@ -1,6 +1,7 @@
 const { isPureObject, isObject } = require('./helpers');
 
 function setMatchingRules(rules, data, path) {
+  if (data.options) console.log(data);
   switch (data.pactum_type) {
     case 'LIKE':
       rules[path] = { match: 'type' };


### PR DESCRIPTION
This PR adds optional non-breaking min and max criteria for ints and floats in pactum-matchers. I have that updates pactum to use this project as a PR dependency that would make debugging easier in the future.